### PR TITLE
Add asymmetric X/Y tiling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
-# ComfyUI-seamless-tiling  
-ComfyUI nodes for generating seamless textures.  
-Replicates "Tiling" option from A1111.  
+# ComfyUI-seamless-tiling
 
-Use "Seamless Tile" node between loader and samplers to modify model, and "Circular VAE Decode" node to decode image.  
+![tile](https://github.com/spacepxl/ComfyUI-seamless-tiling/assets/143970342/2cc548d6-b29e-4e7e-ac89-081498b47fe6)
+
+ComfyUI nodes for generating seamless textures. Replicates "Tiling" option from A1111, including independent X/Y tiling.
+
+Use "Seamless Tile" node between loader and samplers to modify model, and "Make Circular VAE" or "Circular VAE Decode" node to decode image. (Make Circular VAE is more efficient, since it only modifies the VAE model once instead of on each decode)
+
 "Offset Image" node to check for seams.
 
 Circular VAE Decode code from https://github.com/FlyingFireCo/tiled_ksampler
+
+X/Y tiling implementation modified from https://github.com/tjm35/asymmetric-tiling-sd-webui
+
+```
+conditioning/Seamless Tile  
+latent/Circular VAE Decode (tile)  
+latent/Make Circular VAE  
+image/Offset Image  
+```

--- a/SeamlessTile.py
+++ b/SeamlessTile.py
@@ -1,4 +1,5 @@
 import copy
+from typing import Optional
 
 import PIL
 import torch
@@ -6,7 +7,6 @@ from torch import Tensor
 from torch.nn import Conv2d
 from torch.nn import functional as F
 from torch.nn.modules.utils import _pair
-from typing import Optional
 
 
 class SeamlessTile:
@@ -42,11 +42,6 @@ class SeamlessTile:
         return (model_copy,)
 
 
-def make_circular(m):
-    if isinstance(m, torch.nn.Conv2d):
-        m.padding_mode = "circular"
-
-
 # asymmetric tiling from https://github.com/tjm35/asymmetric-tiling-sd-webui/blob/main/scripts/asymmetric_tiling.py
 def make_circular_asymm(model, tileX: bool, tileY: bool):
     for layer in [
@@ -64,11 +59,6 @@ def __replacementConv2DConvForward(self, input: Tensor, weight: Tensor, bias: Op
     working = F.pad(input, self.paddingX, mode=self.padding_modeX)
     working = F.pad(working, self.paddingY, mode=self.padding_modeY)
     return F.conv2d(working, weight, bias, self.stride, _pair(0), self.dilation, self.groups)
-
-
-def unmake_circular(m):
-    if isinstance(m, torch.nn.Conv2d):
-        m.padding_mode = "zeros"
 
 
 class CircularVAEDecode:
@@ -158,7 +148,6 @@ class OffsetImage:
     CATEGORY = "image"
 
     def run(self, pixels, x_percent, y_percent):
-        print(pixels.size())
         n, y, x, c = pixels.size()
         y = round(y * y_percent / 100)
         x = round(x * x_percent / 100)


### PR DESCRIPTION
I added options for X only or Y only tiling based on https://github.com/tjm35/asymmetric-tiling-sd-webui, including for VAE (couldn't find any implementations of it in comfy, but the same patch function can work for both)

Also changed defaults for all nodes from modify in place to make a copy, to simplify workflows with a combination of tiled and not tiled use. Any workflows that were already set up with modify in place should be unaffected.